### PR TITLE
Allow publish without expose, use non-deprecated api, state docker version requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,9 @@ Inspired by the excellent `Jepsen <http://aphyr.com/tags/jepsen>`_ series.
 Requirements
 ============
 
-Docker must be installed and configured to use the LXC driver. The
+Docker must be installed (>= 1.4.0 due to docker-py API requirements, <= 1.6.2
+due to `Docker issue #15231 <https://github.com/docker/docker/issues/15231>`_)
+and configured to use the LXC driver. The
 ``native`` libcontainer driver is not yet supported by Blockade because
 it does not expose the necessary network parameters.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision "docker",
-    images: ["ubuntu"]
+    images: ["ubuntu"], version: "1.6.2"
 
   # kick off the tests automatically
   config.vm.provision "shell", inline: script

--- a/blockade/config.py
+++ b/blockade/config.py
@@ -38,7 +38,11 @@ class BlockadeContainerConfig(object):
         self.lxc_conf = dict(lxc_conf or {})
         self.volumes = _dictify(volumes, "volumes")
         self.publish_ports = _dictify(publish_ports, "ports")
-        self.expose_ports = [int(port) for port in (expose_ports or [])]
+        # All published ports must also be exposed
+        self.expose_ports = list(set(
+            int(port) for port in
+            (expose_ports or []) + list(self.publish_ports.values())
+        ))
         self.environment = dict(environment or {})
 
 

--- a/blockade/config.py
+++ b/blockade/config.py
@@ -38,7 +38,7 @@ class BlockadeContainerConfig(object):
         self.lxc_conf = dict(lxc_conf or {})
         self.volumes = _dictify(volumes, "volumes")
         self.publish_ports = _dictify(publish_ports, "ports")
-        self.expose_ports = _dictify(expose_ports, "expose")
+        self.expose_ports = [int(port) for port in (expose_ports or [])]
         self.environment = dict(environment or {})
 
 

--- a/blockade/core.py
+++ b/blockade/core.py
@@ -56,10 +56,12 @@ class Blockade(object):
         volumes = list(container.volumes.values()) or None
         links = dict((docker_container_name(blockade_id, link), alias)
                      for link, alias in container.links.items())
+        # The docker api for port bindings is `internal:external`
+        port_bindings = dict((v, k) for k, v in container.publish_ports.items())
         lxc_conf = deepcopy(container.lxc_conf)
         lxc_conf['lxc.network.veth.pair'] = veth_device
         host_config = docker.utils.create_host_config(binds=container.volumes,
-            port_bindings=container.publish_ports, links=links, lxc_conf=lxc_conf)
+            port_bindings=port_bindings, links=links, lxc_conf=lxc_conf)
 
         response = self.docker_client.create_container(
             container.image, command=container.command, name=container_name,

--- a/blockade/tests/test_config.py
+++ b/blockade/tests/test_config.py
@@ -129,7 +129,7 @@ class ConfigTests(unittest.TestCase):
         config = BlockadeConfig.from_dict(d)
         self.assertEqual(len(config.containers), 1)
         c1 = config.containers['c1']
-        self.assertEqual(c1.expose_ports, {"10000": "10000"})
+        self.assertEqual(c1.expose_ports, [10000])
 
     def test_parse_fail_1(self):
         containers = {

--- a/blockade/tests/test_config.py
+++ b/blockade/tests/test_config.py
@@ -119,6 +119,18 @@ class ConfigTests(unittest.TestCase):
         c1 = config.containers['c1']
         self.assertEqual(c1.environment, {"HATS": 4, "JACKETS": "some"})
 
+    def test_parse_with_publish_1(self):
+        containers = {
+            "c1": {"image": "image1", "ports": {8080: 80}, "expose": [80]}
+        }
+        d = dict(containers=containers, network={})
+
+        config = BlockadeConfig.from_dict(d)
+        self.assertEqual(len(config.containers), 1)
+        c1 = config.containers['c1']
+        self.assertEqual(c1.expose_ports, [80])
+        self.assertEqual(c1.publish_ports, {'8080': '80'})
+
     def test_parse_with_numeric_port(self):
         containers = {
             "c1": {"image": "image1", "command": "/bin/bash",
@@ -223,6 +235,11 @@ class ConfigTests(unittest.TestCase):
 
         with self.assertRaisesRegexp(BlockadeConfigError, "circular"):
             dependency_sorted(containers)
+
+    def test_publish_without_expose_1(self):
+        cont = BlockadeContainerConfig("c1", "image",
+            expose_ports=[], publish_ports={8080: 80})
+        self.assertEqual(cont.expose_ports, [80])
 
     def assertDependencyLevels(self, seq, *levels):
         self.assertEquals(len(seq), sum(len(l) for l in levels))

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -90,7 +90,8 @@ for details.
 ``ports``
 ---------
 
-``ports`` is optional and specifies ports published to the host machine. 
+``ports`` is optional and specifies ports published to the host machine. It is
+a dictionary from external port to internal container port.
 
 Network
 -------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,9 @@
 Requirements
 ============
 
-Docker must be installed and configured to use the LXC driver. The
+Docker must be installed (>= 1.4.0 due to docker-py API requirements, <= 1.6.2
+due to `Docker issue #15231 <https://github.com/docker/docker/issues/15231>`_)
+and configured to use the LXC driver. The
 ``native`` libcontainer driver is not yet supported by Blockade because
 it does not expose the necessary network parameters.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==3.11
 clint==0.4.1
-docker-py==0.7.0
+# Next version, 1.0.0, requires Docker 1.5
+docker-py==0.7.2
 six==1.9.0


### PR DESCRIPTION
These are a bunch of misc fixes which are useful independent of any native execution driver.

I believe this PR will fix #12 - at some point after 1.4, Docker started requiring you expose a port if you want to publish it.

There's one commit in here ("Expose must be a list as of 1.7.0") which is a bit odd given my discovery that 1.6.2 is the max version of docker available with the LXC driver - this is in preparation for native driver support.

NOTE BREAKING CHANGE: I have swapped the order of port publishing to be `{external: internal}` (like fig and the docker command line) - the Docker api accepts it as `{internal: external}`, so it now has to be swapped round. Apparently even the blockade documentation was confused about this! http://blockade.readthedocs.org/en/latest/config.html