### PR TITLE
Fix integration tests. Latest ubuntu (xenial) images do not have iproute2 installed by default.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # fetch the ubuntu:latest image that is required for
   # the test suite
   config.vm.provision "docker",
-    images: ["ubuntu"]
+    images: ["ubuntu:trusty"]
 
   # kick off the tests automatically
   config.vm.provision "shell", inline: script

--- a/blockade/tests/test_integration.py
+++ b/blockade/tests/test_integration.py
@@ -173,11 +173,11 @@ class IntegrationTests(unittest.TestCase):
                 f.write(dedent('''\
                     containers:
                       zzz:
-                        image: ubuntu
+                        image: ubuntu:trusty
                         command: sleep infinity
                         expose: [10000]
                       aaa:
-                        image: ubuntu
+                        image: ubuntu:trusty
                         command: sleep infinity
                         links: ["zzz"]
                     '''))

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -38,17 +38,17 @@ these contents:
 
     containers:
       c1:
-        image: ubuntu
+        image: ubuntu:trusty
         command: /bin/sleep 300000
         ports: [10000]
 
       c2:
-        image: ubuntu
+        image: ubuntu:trusty
         command: sh -c "ping $C1_PORT_10000_TCP_ADDR"
         links: ["c1"]
 
       c3:
-        image: ubuntu
+        image: ubuntu:trusty
         command: sh -c "ping $C1_PORT_10000_TCP_ADDR"
         links: ["c1"]
 
@@ -56,8 +56,8 @@ these contents:
 This configuration specifies the three containers we described above. Note
 that we rely on Docker `named links`_ which require at least one open port.
 Hence our sleeping ``c1`` container has a fake port 10000 open.
-The ``ubuntu`` image must exist in your Docker installation.
-You can download it using the docker pull command ``sudo docker pull ubuntu``.
+The ``ubuntu:trusty`` image must exist in your Docker installation.
+You can download it using the docker pull command ``sudo docker pull ubuntu:trusty``.
 
 Start the Blockade
 ------------------

--- a/examples/ping/blockade.yaml
+++ b/examples/ping/blockade.yaml
@@ -1,19 +1,19 @@
 containers:
   c1:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c1
     command: /bin/sleep 30000
     # this port is unused, but we need at least one open for docker links
     expose: [10000]
 
   c2:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c2
     command: sh -c "ping -i1 $C1_PORT_10000_TCP_ADDR"
     links: ["c1"]
 
   c3:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c3
     command: sh -c "ping -i1 $C1_PORT_10000_TCP_ADDR"
     links: ["c1"]

--- a/examples/sleep/blockade.yaml
+++ b/examples/sleep/blockade.yaml
@@ -1,16 +1,16 @@
 containers:
   c1:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c1
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
     volumes: {"/tmp": "/mnt"}
 
   c2:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c2
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
 
   c3:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c3
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'


### PR DESCRIPTION
It seems that current latest ubuntu image doesn't have iproute2 package installed. So integration tests are failing.

```bash
vagrant@vagrant-ubuntu-trusty-64:~$ docker run -t -i ubuntu:latest
root@688812c500c8:/# ip token
bash: ip: command not found
root@688812c500c8:/# exit
vagrant@vagrant-ubuntu-trusty-64:~$ docker run -t -i ubuntu:trusty
root@847c8801a90c:/# ip token
token :: dev eth0 
root@847c8801a90c:/# exit
```
One way is just to stick with trusty image (as in proposed patch).
Also integration test suite doesn't actually catches  printed errors, but i didn't dig into that.
