### PR TITLE
Adds kill command with optional signal that can be specified

### DIFF
--- a/blockade/cli.py
+++ b/blockade/cli.py
@@ -149,7 +149,9 @@ def __with_containers(opts, func):
     configured_containers = set(state.containers.keys())
     container_names = configured_containers if select_all or None else configured_containers.intersection(containers)
 
-    if len(container_names) > 0:
+    if len(container_names) > 0 and hasattr(opts, 'signal'):
+        return func(b, container_names, state, signal=opts.signal)
+    elif len(container_names) > 0:
         return func(b, container_names, state)
     else:
         raise BlockadeError('selection does not match any container')
@@ -159,6 +161,12 @@ def cmd_start(opts):
     """Start some or all containers
     """
     __with_containers(opts, Blockade.start)
+
+
+def cmd_kill(opts):
+    """Kill some or all containers
+    """
+    __with_containers(opts, Blockade.kill)
 
 
 def cmd_stop(opts):
@@ -258,6 +266,7 @@ _CMDS = (("up", cmd_up),
          ("start", cmd_start),
          ("restart", cmd_restart),
          ("stop", cmd_stop),
+         ("kill", cmd_kill),
          ("logs", cmd_logs),
          ("flaky", cmd_flaky),
          ("slow", cmd_slow),
@@ -298,6 +307,7 @@ def setup_parser():
     _add_output_options(command_parsers["status"])
 
     _add_container_selection_options(command_parsers["start"])
+    _add_container_selection_options(command_parsers["kill"])
     _add_container_selection_options(command_parsers["stop"])
     _add_container_selection_options(command_parsers["restart"])
     _add_container_selection_options(command_parsers["flaky"])
@@ -312,6 +322,9 @@ def setup_parser():
         help='Comma-separated partition')
     command_parsers["partition"].add_argument("-z", "--random", action='store_true',
         help='Randomly select zero or more partitions')
+
+    command_parsers["kill"].add_argument("-s", "--signal", action="store", default="SIGKILL",
+        help="Specify the signal to be sent (str or int). Defaults to SIGKILL.")
 
     return parser
 

--- a/blockade/cli.py
+++ b/blockade/cli.py
@@ -140,7 +140,7 @@ def cmd_status(opts):
     print_containers(containers, opts.json)
 
 
-def __with_containers(opts, func):
+def __with_containers(opts, func, **kwargs):
     containers, select_all = _check_container_selections(opts)
     config = load_config(opts.config)
     b = get_blockade(config)
@@ -149,10 +149,8 @@ def __with_containers(opts, func):
     configured_containers = set(state.containers.keys())
     container_names = configured_containers if select_all or None else configured_containers.intersection(containers)
 
-    if len(container_names) > 0 and hasattr(opts, 'signal'):
-        return func(b, container_names, state, signal=opts.signal)
-    elif len(container_names) > 0:
-        return func(b, container_names, state)
+    if len(container_names) > 0:
+        return func(b, container_names, state, **kwargs)
     else:
         raise BlockadeError('selection does not match any container')
 
@@ -166,7 +164,8 @@ def cmd_start(opts):
 def cmd_kill(opts):
     """Kill some or all containers
     """
-    __with_containers(opts, Blockade.kill)
+    signal = opts.signal if hasattr(opts, 'signal') else "SIGKILL"
+    __with_containers(opts, Blockade.kill, signal = signal)
 
 
 def cmd_stop(opts):

--- a/blockade/core.py
+++ b/blockade/core.py
@@ -302,6 +302,14 @@ class Blockade(object):
             self._stop(container)
             state = self._start(container.name, state)
 
+    def kill(self, container_names, state, signal="SIGKILL"):
+        containers = self._get_running_containers(container_names, state)
+        for container in containers:
+            self._kill(container, signal)
+
+    def _kill(self, container, signal):
+        self.docker_client.kill(container.container_id, signal)
+
     def stop(self, container_names, state):
         containers = self._get_running_containers(container_names, state)
         for container in containers:

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -69,6 +69,23 @@ system (``blockade --help``).
 
       --all       Select all containers
 
+``kill``
+----------
+
+::
+
+    usage: blockade kill [--all] [--signal] [CONTAINER [CONTAINER ...]]
+
+    Kill some or all containers
+
+      CONTAINER   Container to select
+
+      --all       Select all containers
+
+    optional arguments:
+
+      --signal      Specify the signal to be sent (str or int). Defaults to SIGKILL.
+
 ``restart``
 ----------
 


### PR DESCRIPTION
The stop command sends SIGTERM and only sends SIGKILL if graceful shutdown doesn't occur within a specified timeout (default 10s), kill allows blockade to send SIGKILL (or any other specified signal) to a container immediately.