### PR TITLE
fix links of named containers

### DIFF
--- a/blockade/config.py
+++ b/blockade/config.py
@@ -98,7 +98,13 @@ class BlockadeContainerConfig(object):
             int(port) for port in
             (expose_ports or []) + list(self.publish_ports.values())
         ))
+
         self.environment = _dictify(environment, _populate_env, _populate_env)
+
+    def get_name(self, blockade_id):
+        if self.container_name:
+            return self.container_name
+        return '_'.join((blockade_id, self.name))
 
 
 _DEFAULT_NETWORK_CONFIG = {

--- a/blockade/core.py
+++ b/blockade/core.py
@@ -111,11 +111,21 @@ class Blockade(object):
             raise
         return device
 
+    def __get_container_links(self, container):
+        links = {}
+        for link, alias in container.links.items():
+            link_container = self.config.containers.get(link, None)
+            if not link_container:
+                raise BlockadeError("link '%s' of container '%s' does not exist" %
+                                    (link, container.name))
+            name = link_container.get_name(self.state.blockade_id)
+            links[name] = alias
+        return links
+
     def _start_container(self, container, force=False):
-        container_name = container.container_name or docker_container_name(self.state.blockade_id, container.name)
+        container_name = container.get_name(self.state.blockade_id)
         volumes = list(container.volumes.values()) or None
-        links = dict((docker_container_name(self.state.blockade_id, link), alias)
-                     for link, alias in container.links.items())
+        links = self.__get_container_links(container)
 
         # the docker api for port bindings is `internal:external`
         port_bindings = dict((v, k) for k, v in container.publish_ports.items())
@@ -435,10 +445,6 @@ class ContainerStatus(object):
     UP = "UP"
     DOWN = "DOWN"
     MISSING = "MISSING"
-
-
-def docker_container_name(blockade_id, name):
-    return '_'.join((blockade_id, name))
 
 
 def expand_partitions(containers, partitions):

--- a/blockade/net.py
+++ b/blockade/net.py
@@ -300,19 +300,19 @@ def partition_containers(blockade_id, partitions):
 
 def traffic_control_restore(device):
     cmd = ["tc", "qdisc", "del", "dev", device, "root"]
-    docker_run(' '.join(cmd))
+    docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
 
 
 def traffic_control_netem(device, params):
     cmd = ["tc", "qdisc", "replace", "dev", device,
            "root", "netem"] + params
-    docker_run(' '.join(cmd))
+    docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
 
 
 def network_state(device):
     cmd = ["tc", "qdisc", "show", "dev", device]
     try:
-        output = docker_run(' '.join(cmd))
+        output = docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
         # sloppy but good enough for now
         if " delay " in output:
             return NetworkState.SLOW

--- a/blockade/tests/test_net.py
+++ b/blockade/tests/test_net.py
@@ -298,7 +298,7 @@ class NetTests(unittest.TestCase):
             net.slow("mydevice")
             cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
                    "root", "netem", "delay"] + slow_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd))
+            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
 
     def test_flaky(self):
         flaky_config = "30%"
@@ -309,7 +309,7 @@ class NetTests(unittest.TestCase):
             net.flaky("mydevice")
             cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
                    "root", "netem", "loss"] + flaky_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd))
+            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
 
     def test_duplicate(self):
         duplicate_config = "5%"
@@ -320,7 +320,7 @@ class NetTests(unittest.TestCase):
             net.duplicate("mydevice")
             cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
                    "root", "netem", "duplicate"] + duplicate_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd))
+            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
 
     def test_network_state_slow(self):
         self._network_state(NetworkState.SLOW, SLOW_QDISC_SHOW)


### PR DESCRIPTION
Hi,

this changeset fixes links between containers with overridden names (via `container_name`). 

Moreover I added a minor change to the invocation of the `tc` command, in order to use the `vimagick/iptables` docker image instead of the rather *heavy* ubuntu one.

Cheers,
Gregor