### PR TITLE
Fix blockade.yml to blockade.yaml in docs

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -30,7 +30,7 @@ proceeding. See the `Docker installation docs`_ and :ref:`install`.
 Set up your Blockade config
 ---------------------------
 
-Now create a new directory and in it create a ``blockade.yml`` file with
+Now create a new directory and in it create a ``blockade.yaml`` file with
 these contents:
 
 .. code-block:: yaml


### PR DESCRIPTION
It references to #43 , because in docs I saw only `blockade.yaml` not `blockade.yml`.