### PR TITLE
Ensured iptables chain names are 29 chars or fewer

### DIFF
--- a/blockade/net.py
+++ b/blockade/net.py
@@ -22,6 +22,8 @@ import itertools
 import re
 
 BLOCKADE_CHAIN_PREFIX = "blockade-"
+# iptables chain names are a max of 29 characters so we truncate the prefix
+MAX_CHAIN_PREFIX_LENGTH = 25
 IPTABLES_DOCKER_IMAGE = "vimagick/iptables:latest"
 
 
@@ -96,7 +98,7 @@ class BlockadeNetwork(object):
 
 
 def parse_partition_index(blockade_id, chain):
-    prefix = "%s%s-p" % (BLOCKADE_CHAIN_PREFIX, blockade_id)
+    prefix = "%s-p" % partition_chain_prefix(blockade_id)
     if chain and chain.startswith(prefix):
         try:
             return int(chain[len(prefix):])
@@ -106,7 +108,12 @@ def parse_partition_index(blockade_id, chain):
 
 
 def partition_chain_name(blockade_id, partition_index):
-    return "%s%s-p%s" % (BLOCKADE_CHAIN_PREFIX, blockade_id, partition_index)
+    return "%s-p%s" % (partition_chain_prefix(blockade_id), partition_index)
+
+
+def partition_chain_prefix(blockade_id):
+    prefix = "%s%s" % (BLOCKADE_CHAIN_PREFIX, blockade_id)
+    return prefix[:MAX_CHAIN_PREFIX_LENGTH]
 
 
 def iptables_call_output(*args):

--- a/blockade/tests/test_net.py
+++ b/blockade/tests/test_net.py
@@ -221,6 +221,22 @@ class NetTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_partition_index(blockade_id, "abc123-notanumber")
 
+    def test_partition_long_chain_parse(self):
+        blockade_id = "abc123awhopbopaloobopalopbamboom"
+        self.assertEqual(
+            "blockade-abc123awhopbopal-p1", partition_chain_name(blockade_id, 1)
+        )
+        self.assertEqual(
+            "blockade-abc123awhopbopal-p2", partition_chain_name(blockade_id, 2)
+        )
+
+        index = parse_partition_index(blockade_id,
+                                      partition_chain_name(blockade_id, 1))
+        self.assertEqual(1, index)
+
+        with self.assertRaises(ValueError):
+            parse_partition_index(blockade_id, "abc123")
+
     def test_partition_1(self):
         blockade_id = "e5dcf85cd2"
         expected_image=blockade.net.IPTABLES_DOCKER_IMAGE


### PR DESCRIPTION
Iptables doesn't support chain names longer than 29 characters, and if
they are longer, chain creation fails.

Fixes #36.