### PR TITLE
This patch shows where I have seen blockade getting stuck.

### DIFF
--- a/blockade/utils.py
+++ b/blockade/utils.py
@@ -45,9 +45,14 @@ def docker_run(command,
 
     stdout = docker_client.logs(container=container.get('Id'),
                                 stdout=True, stream=True)
+
+    max_len = 1000000
     output = b''
     for item in stdout:
         output += item
+        if len(output) > max_len:
+            output += "\n...<more>"
+            break
 
     output = output.decode('utf-8')
 


### PR DESCRIPTION
WIP I have noticed blockade getting stuck.  It seems like the logs never stop running so this never ends?  Here is the stack trace:

```=== Stack trace Begin ===
##### Thread 140157740635904 #####
    File: "/usr/local/lib/python2.7/dist-packages/gevent/threadpool.py", line 196, in _worker
    File: "/usr/local/lib/python2.7/dist-packages/gevent/_threading.py", line 435, in get
    File: "/usr/local/lib/python2.7/dist-packages/gevent/_threading.py", line 151, in wait
waiter.acquire()
##### Thread 140157799274240 #####
    File: "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 534, in run
    File: "/usr/local/lib/python2.7/dist-packages/gevent/baseserver.py", line 25, in _handle_and_close_when_done
    File: "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 1253, in handle
    File: "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 443, in handle
    File: "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 658, in handle_one_request
    File: "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 884, in handle_one_response
    File: "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 870, in run_application
    File: "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    File: "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    File: "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    File: "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    File: "/usr/local/lib/python2.7/dist-packages/blockade/api/rest.py", line 115, in add
    File: "/usr/local/lib/python2.7/dist-packages/blockade/core.py", line 485, in add_container
    File: "/usr/local/lib/python2.7/dist-packages/blockade/core.py", line 111, in _init_container
    File: "/usr/local/lib/python2.7/dist-packages/blockade/net.py", line 85, in get_container_device
    File: "/usr/local/lib/python2.7/dist-packages/blockade/utils.py", line 49, in docker_run
    File: "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 252, in _multiplexed_response_stream_helper
    File: "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/response.py", line 380, in read
    File: "/usr/lib/python2.7/httplib.py", line 588, in read
    File: "/usr/lib/python2.7/httplib.py", line 630, in _read_chunked
    File: "/usr/lib/python2.7/socket.py", line 480, in readline
    File: "/usr/local/lib/python2.7/dist-packages/blockade/api/rest.py", line 36, in stack_trace_handler
for filename, lineno, name, line in traceback.extract_stack(stack):
 === Stack trace End ===```

