### PR TITLE
Reuse a single host container for many commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
 language: python
 python:
   - "2.7"

--- a/blockade/api/manager.py
+++ b/blockade/api/manager.py
@@ -27,11 +27,16 @@ DATA_DIR = "/tmp"
 class BlockadeManager:
     """Simple helper for what should eventually be persisted via BlockadeState
     """
+    host_exec = None
 
     @staticmethod
     def set_data_dir(data_dir):
         global DATA_DIR
         DATA_DIR = data_dir
+
+    @staticmethod
+    def set_host_exec(host_exec):
+        BlockadeManager.host_exec = host_exec
 
     @staticmethod
     def blockade_exists(name):
@@ -61,10 +66,13 @@ class BlockadeManager:
     def get_blockade(name):
         global BLOCKADE_CONFIGS
         config = BLOCKADE_CONFIGS[name]
+        host_exec = BlockadeManager.host_exec
+        if host_exec is None:
+            raise ValueError("host exec not set")
         return Blockade(config,
                         blockade_id=name,
                         state=BlockadeManager.load_state(name),
-                        network=BlockadeNetwork(config))
+                        network=BlockadeNetwork(config, host_exec))
 
     @staticmethod
     def get_all_blockade_names():

--- a/blockade/api/rest.py
+++ b/blockade/api/rest.py
@@ -45,10 +45,12 @@ def stack_trace_handler(signum, frame):
     app.logger.warn("\n".join(code))
 
 
-def start(data_dir='/tmp', port=5000, debug=False):
+def start(data_dir='/tmp', port=5000, debug=False, host_exec=None):
     signal.signal(signal.SIGUSR2, stack_trace_handler)
 
     BlockadeManager.set_data_dir(data_dir)
+    if host_exec:
+        BlockadeManager.set_host_exec(host_exec)
     app.debug = debug
     http_server = WSGIServer(('', port), app)
     http_server.serve_forever()

--- a/blockade/core.py
+++ b/blockade/core.py
@@ -31,7 +31,6 @@ from .errors import BlockadeContainerConflictError
 from .errors import BlockadeError
 from .errors import DockerContainerNotFound
 from .errors import InsufficientPermissionsError
-from .net import BlockadeNetwork
 from .net import NetworkState
 from .state import BlockadeState
 
@@ -47,7 +46,7 @@ class Blockade(object):
                  network=None, docker_client=None):
         self.config = config
         self.state = state or BlockadeState(blockade_id=blockade_id)
-        self.network = network or BlockadeNetwork(config)
+        self.network = network
         try:
             self._audit = audit.EventAuditor(self.state.get_audit_file())
         except Exception as ex:

--- a/blockade/errors.py
+++ b/blockade/errors.py
@@ -65,6 +65,24 @@ class DockerContainerNotFound(BlockadeError):
     """
 
 
+class HostExecError(BlockadeError):
+    """Error in host command
+    """
+
+    def __init__(self, message, output=None, exit_code=None):
+        super(HostExecError, self).__init__(message)
+        self.output = output
+        self.exit_code = exit_code
+
+    def __str__(self):
+        message = super(HostExecError, self).__str__()
+        if self.exit_code is not None and self.output is not None:
+            return "%s rc=%s output=%s" % (message, self.exit_code, self.output)
+        if self.output is not None:
+            return "%s output=%s" % (message, self.output)
+        return message
+
+
 class BlockadeStateTransitionError(BlockadeError):
     """The state machine was given an invalid event.  Based on the state that
      it is in and the event received the state machine could not process the

--- a/blockade/host.py
+++ b/blockade/host.py
@@ -1,0 +1,168 @@
+#
+#  Copyright (C) 2017 Quest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import logging
+import threading
+import time
+import uuid
+
+import docker
+
+from .errors import HostExecError
+
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_IMAGE = 'vimagick/iptables:latest'
+DEFAULT_CONTAINER_PREFIX = 'blockade-helper'
+CONTAINER_PREFIX_ENV = "BLOCKADE_HOST_CONTAINER_PREFIX"
+
+
+class HostExec(object):
+    """Runs host commands via exec in a long-lived container
+
+    A container is launched on the first attempt to run a command. The
+    container runs a sleep command with a configurable timeout - to ensure
+    it stops running if orphaned. But to guard against race conditions where
+    blockade attempts to use a container just as it is dying, we also have
+    a separate expiration threshold, where blockade will automatically discard
+    an old container well before it would die.
+    """
+
+    def __init__(self, image=DEFAULT_IMAGE, container_timeout=3600,
+                 container_expire=3000, container_prefix=None,
+                 docker_client=None):
+        self._image = image
+        self._container_timeout = container_timeout
+        self._container_expire = container_expire
+
+        if container_prefix:
+            self._container_prefix = container_prefix
+        elif os.environ.get(CONTAINER_PREFIX_ENV):
+            self._container_prefix = os.environ[CONTAINER_PREFIX_ENV]
+        else:
+            self._container_prefix = DEFAULT_CONTAINER_PREFIX
+
+        self._docker_client = docker_client or docker.Client(
+            **docker.utils.kwargs_from_env(assert_hostname=False)
+        )
+        self._lock = threading.RLock()
+        self._reset_container()
+
+    def run(self, command):
+
+        _logger.debug("Running host command '%s'", command)
+
+        def _exec():
+            self._assure_container()
+            exec_handle = self._docker_client.exec_create(self._container_id,
+                command)
+            output = self._docker_client.exec_start(exec_handle).decode('utf-8')
+            exec_details = self._docker_client.exec_inspect(exec_handle)
+            exit_code = exec_details['ExitCode']
+            if exit_code != 0:
+                raise HostExecError(("Error running host command '%s'" %
+                    (command,)), exit_code=exit_code, output=output)
+
+            return output
+
+        try:
+            return _exec()
+
+        except docker.errors.NotFound:
+            # container was removed out-of-band. replace it and retry
+            with self._lock:
+                self._reset_container()
+            return _exec()
+
+        except (docker.errors.APIError, docker.errors.DockerException):
+            # unknown Docker error, most likely a dead container.
+            # replace it and retry
+            _logger.debug("Docker error running command '%s'", command,
+                          exc_info=True)
+            with self._lock:
+                self._remove_container()
+            return _exec()
+
+    def close(self):
+        _logger.debug("Closing host exec system")
+        with self._lock:
+            self._remove_container()
+
+    def _assure_container(self):
+        with self._lock:
+            if self._container_id is None:
+                self._create_container()
+            elif self._container_is_expired():
+                self._remove_container()
+                self._create_container()
+
+    def _container_is_expired(self):
+        if not self._container_id:
+            return True
+        return self._container_expire_time <= time.time()
+
+    def _create_container(self):
+        command = "sleep %d" % self._container_timeout
+        name = '-'.join((self._container_prefix, uuid.uuid4().hex))
+
+        _logger.debug("creating host container image=%s cmd='%s' name=%s",
+            self._image, command, name)
+
+        def _create():
+            return self._docker_client.create_container(
+                image=self._image, command=command, name=name)
+
+        try:
+            container = _create()
+        except docker.errors.NotFound:
+            self._docker_client.pull(self._image)
+            container = _create()
+
+        container_id = container.get('Id')
+        self._docker_client.start(container=container_id,
+                            network_mode="host", privileged=True)
+
+        self._container_id = container_id
+        self._container_expire_time = time.time() + float(self._container_expire)
+
+    def _remove_container(self):
+        if self._container_id:
+
+            _logger.debug("Cleaning up host container %s", self._container_id)
+
+            needs_remove = True
+            try:
+                self._docker_client.kill(self._container_id)
+            except docker.errors.NotFound:
+                needs_remove = False
+            except (docker.errors.APIError, docker.errors.DockerException):
+                _logger.debug("Error attempting to kill host container %s",
+                              self._container_id, exc_info=True)
+
+            if needs_remove:
+                try:
+                    self._docker_client.remove_container(
+                        container=self._container_id, force=True)
+                except docker.errors.NotFound:
+                    pass
+
+        self._reset_container()
+
+    def _reset_container(self):
+        self._container_id = None
+        self._container_expire_time = 0

--- a/blockade/net.py
+++ b/blockade/net.py
@@ -18,9 +18,12 @@ import docker
 import collections
 import itertools
 import re
+import logging
 
-from .errors import BlockadeError
-from .utils import docker_run
+from .errors import BlockadeError, HostExecError
+
+
+_logger = logging.getLogger(__name__)
 
 
 BLOCKADE_CHAIN_PREFIX = "blockade-"
@@ -40,36 +43,39 @@ class NetworkState(object):
 
 
 class BlockadeNetwork(object):
-    def __init__(self, config):
+    def __init__(self, config, host_exec):
         self.config = config
+        self.host_exec = host_exec
+        self.iptables = _IPTables(host_exec)
+        self.traffic_control = _TrafficControl(host_exec)
 
     def network_state(self, device):
-        return network_state(device)
+        return self.traffic_control.network_state(device)
 
     def flaky(self, device):
         flaky_config = self.config.network['flaky'].split()
-        traffic_control_netem(device, ["loss"] + flaky_config)
+        self.traffic_control.netem(device, ["loss"] + flaky_config)
 
     def slow(self, device):
         slow_config = self.config.network['slow'].split()
-        traffic_control_netem(device, ["delay"] + slow_config)
+        self.traffic_control.netem(device, ["delay"] + slow_config)
 
     def duplicate(self, device):
         duplicate_config = self.config.network['duplicate'].split()
-        traffic_control_netem(device, ["duplicate"] + duplicate_config)
+        self.traffic_control.netem(device, ["duplicate"] + duplicate_config)
 
     def fast(self, device):
-        traffic_control_restore(device)
+        self.traffic_control.restore(device)
 
     def restore(self, blockade_id):
-        clear_iptables(blockade_id)
+        self.iptables.clear(blockade_id)
 
     def partition_containers(self, blockade_id, partitions):
-        clear_iptables(blockade_id)
-        partition_containers(blockade_id, partitions)
+        self.iptables.clear(blockade_id)
+        self._partition_containers(blockade_id, partitions)
 
     def get_ip_partitions(self, blockade_id):
-        return iptables_get_source_chains(blockade_id)
+        return self.iptables.get_source_chains(blockade_id)
 
     def get_container_device(self, docker_client, container_id):
         container_idx = get_container_device_index(docker_client, container_id)
@@ -80,9 +86,10 @@ class BlockadeNetwork(object):
 
         cmd = 'ip link'
         try:
-            host_res = docker_run(cmd, image=IPTABLES_DOCKER_IMAGE,
-                                  docker_client=docker_client)
+            host_res = self.host_exec.run(cmd)
         except Exception as e:
+            _logger.error("error listing host network interfaces", exc_info=True)
+
             raise BlockadeError(
                 "%s:\nerror listing host network interfaces with: "
                 "'docker run --network=host %s %s':\n%s" %
@@ -98,6 +105,202 @@ class BlockadeNetwork(object):
             "'ip link' output:\n %s\n\nThis may be a Blockade bug, or "
             "there may be something unusual about your container network."
             % (_ERROR_NET_IFACE, host_idx, container_id, host_res))
+
+    def _partition_containers(self, blockade_id, partitions):
+        if not partitions or len(partitions) == 1:
+            return
+
+        # partitions without IP addresses can't be part of any
+        # iptables rule anyway
+        ip_partitions = [[c for c in parts if c.ip_address] for parts in partitions]
+
+        all_nodes = frozenset(itertools.chain(*ip_partitions))
+
+        for idx, chain_group in enumerate(_get_chain_groups(ip_partitions)):
+            # create a new chain
+            chain_name = partition_chain_name(blockade_id, idx+1)
+            self.iptables.create_chain(chain_name)
+
+            # direct all traffic of the chain group members to this chain
+            for container in chain_group:
+                self.iptables.insert_rule("FORWARD", src=container.ip_address, target=chain_name)
+
+            def in_group(container):
+                return any(container.name == x.name for x in chain_group)
+
+            # block all transfer of partitions the containers of this chain group  are NOT part of
+            chain_partition_members = set(itertools.chain(*[parts for parts in ip_partitions
+                                                            if any(in_group(c) for c in parts)]))
+            to_block = all_nodes - chain_partition_members
+
+            for container in to_block:
+                self.iptables.insert_rule(chain_name, dest=container.ip_address, target="DROP")
+
+
+class _IPTables(object):
+
+    def __init__(self, host_exec):
+        self.host_exec = host_exec
+
+    def call_output(self, *args):
+        cmd = ["iptables", "-n"] + list(args)
+        output = self.host_exec.run(cmd)
+        return output.split('\n')
+
+    def call(self, *args):
+        cmd = ["iptables"] + list(args)
+        return self.host_exec.run(cmd)
+
+    def get_chain_rules(self, chain):
+        if not chain:
+            raise ValueError("invalid chain")
+        lines = self.call_output("-L", chain)
+        if len(lines) < 2:
+            raise BlockadeError("Can't understand iptables output: \n%s" %
+                                "\n".join(lines))
+
+        chain_line, header_line = lines[:2]
+        if not (chain_line.startswith("Chain " + chain) and
+                header_line.startswith("target")):
+            raise BlockadeError("Can't understand iptables output: \n%s" %
+                                "\n".join(lines))
+        return lines[2:]
+
+    def get_source_chains(self, blockade_id):
+        """Get a map of blockade chains IDs -> list of IPs targeted at them
+
+        For figuring out which container is in which partition
+        """
+        result = {}
+        if not blockade_id:
+            raise ValueError("invalid blockade_id")
+        lines = self.get_chain_rules("FORWARD")
+
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            try:
+                partition_index = parse_partition_index(blockade_id, parts[0])
+            except ValueError:
+                continue  # not a rule targetting a blockade chain
+
+            source = parts[3]
+            if source:
+                result[source] = partition_index
+        return result
+
+    def delete_rules(self, chain, predicate):
+        if not chain:
+            raise ValueError("invalid chain")
+        if not isinstance(predicate, collections.Callable):
+            raise ValueError("invalid predicate")
+
+        lines = self.get_chain_rules(chain)
+
+        # TODO this is susceptible to check-then-act races.
+        # better to ultimately switch to python-iptables if it becomes less buggy
+        for index, line in reversed(list(enumerate(lines, 1))):
+            line = line.strip()
+            if line and predicate(line):
+                self.call("-D", chain, str(index))
+
+    def delete_blockade_rules(self, blockade_id):
+        def predicate(rule):
+            target = rule.split()[0]
+            try:
+                parse_partition_index(blockade_id, target)
+            except ValueError:
+                return False
+            return True
+        self.delete_rules("FORWARD", predicate)
+
+    def delete_blockade_chains(self, blockade_id):
+        if not blockade_id:
+            raise ValueError("invalid blockade_id")
+
+        lines = self.call_output("-L")
+        for line in lines:
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == "Chain":
+                chain = parts[1]
+                try:
+                    parse_partition_index(blockade_id, chain)
+                except ValueError:
+                    continue
+                # if we are a valid blockade chain, flush and delete
+                self.call("-F", chain)
+                self.call("-X", chain)
+
+    def insert_rule(self, chain, src=None, dest=None, target=None):
+        """Insert a new rule in the chain
+        """
+        if not chain:
+            raise ValueError("Invalid chain")
+        if not target:
+            raise ValueError("Invalid target")
+        if not (src or dest):
+            raise ValueError("Need src, dest, or both")
+
+        args = ["-I", chain]
+        if src:
+            args += ["-s", src]
+        if dest:
+            args += ["-d", dest]
+        args += ["-j", target]
+        self.call(*args)
+
+    def create_chain(self, chain):
+        """Create a new chain
+        """
+        if not chain:
+            raise ValueError("Invalid chain")
+        self.call("-N", chain)
+
+    def clear(self, blockade_id):
+        """Remove all iptables rules and chains related to this blockade
+        """
+        # first remove refererences to our custom chains
+        self.delete_blockade_rules(blockade_id)
+
+        # then remove the chains themselves
+        self.delete_blockade_chains(blockade_id)
+
+
+class _TrafficControl(object):
+    def __init__(self, host_exec):
+        self.host_exec = host_exec
+
+    def restore(self, device):
+        cmd = ["tc", "qdisc", "del", "dev", device, "root"]
+        try:
+            self.host_exec.run(cmd)
+        except HostExecError as e:
+            if e.exit_code == 2 and 'No such file or directory' in e.output:
+                pass  # this is an expected condition
+            else:
+                raise
+
+
+    def netem(self, device, params):
+        cmd = ["tc", "qdisc", "replace", "dev", device,
+               "root", "netem"] + params
+        self.host_exec.run(cmd)
+
+    def network_state(self, device):
+        cmd = ["tc", "qdisc", "show", "dev", device]
+        try:
+            output = self.host_exec.run(cmd)
+            # sloppy but good enough for now
+            if " delay " in output:
+                return NetworkState.SLOW
+            if " loss " in output:
+                return NetworkState.FLAKY
+            if " duplicate " in output:
+                return NetworkState.DUPLICATE
+            return NetworkState.NORMAL
+        except Exception:
+            return NetworkState.UNKNOWN
 
 
 def get_container_device_index(docker_client, container_id):
@@ -146,140 +349,6 @@ def partition_chain_prefix(blockade_id):
     return prefix[:MAX_CHAIN_PREFIX_LENGTH]
 
 
-def iptables_call_output(*args):
-    cmd = ["iptables", "-n"] + list(args)
-    output = docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
-    return output.split('\n')
-
-
-def iptables_call(*args):
-    cmd = ["iptables"] + list(args)
-    return docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
-
-
-def iptables_get_chain_rules(chain):
-    if not chain:
-        raise ValueError("invalid chain")
-    lines = iptables_call_output("-L", chain)
-    if len(lines) < 2:
-        raise BlockadeError("Can't understand iptables output: \n%s" %
-                            "\n".join(lines))
-
-    chain_line, header_line = lines[:2]
-    if not (chain_line.startswith("Chain " + chain) and
-            header_line.startswith("target")):
-        raise BlockadeError("Can't understand iptables output: \n%s" %
-                            "\n".join(lines))
-    return lines[2:]
-
-
-def iptables_get_source_chains(blockade_id):
-    """Get a map of blockade chains IDs -> list of IPs targeted at them
-
-    For figuring out which container is in which partition
-    """
-    result = {}
-    if not blockade_id:
-        raise ValueError("invalid blockade_id")
-    lines = iptables_get_chain_rules("FORWARD")
-
-    for line in lines:
-        parts = line.split()
-        if len(parts) < 4:
-            continue
-        try:
-            partition_index = parse_partition_index(blockade_id, parts[0])
-        except ValueError:
-            continue  # not a rule targetting a blockade chain
-
-        source = parts[3]
-        if source:
-            result[source] = partition_index
-    return result
-
-
-def iptables_delete_rules(chain, predicate):
-    if not chain:
-        raise ValueError("invalid chain")
-    if not isinstance(predicate, collections.Callable):
-        raise ValueError("invalid predicate")
-
-    lines = iptables_get_chain_rules(chain)
-
-    # TODO this is susceptible to check-then-act races.
-    # better to ultimately switch to python-iptables if it becomes less buggy
-    for index, line in reversed(list(enumerate(lines, 1))):
-        line = line.strip()
-        if line and predicate(line):
-            iptables_call("-D", chain, str(index))
-
-
-def iptables_delete_blockade_rules(blockade_id):
-    def predicate(rule):
-        target = rule.split()[0]
-        try:
-            parse_partition_index(blockade_id, target)
-        except ValueError:
-            return False
-        return True
-    iptables_delete_rules("FORWARD", predicate)
-
-
-def iptables_delete_blockade_chains(blockade_id):
-    if not blockade_id:
-        raise ValueError("invalid blockade_id")
-
-    lines = iptables_call_output("-L")
-    for line in lines:
-        parts = line.split()
-        if len(parts) >= 2 and parts[0] == "Chain":
-            chain = parts[1]
-            try:
-                parse_partition_index(blockade_id, chain)
-            except ValueError:
-                continue
-            # if we are a valid blockade chain, flush and delete
-            iptables_call("-F", chain)
-            iptables_call("-X", chain)
-
-
-def iptables_insert_rule(chain, src=None, dest=None, target=None):
-    """Insert a new rule in the chain
-    """
-    if not chain:
-        raise ValueError("Invalid chain")
-    if not target:
-        raise ValueError("Invalid target")
-    if not (src or dest):
-        raise ValueError("Need src, dest, or both")
-
-    args = ["-I", chain]
-    if src:
-        args += ["-s", src]
-    if dest:
-        args += ["-d", dest]
-    args += ["-j", target]
-    iptables_call(*args)
-
-
-def iptables_create_chain(chain):
-    """Create a new chain
-    """
-    if not chain:
-        raise ValueError("Invalid chain")
-    iptables_call("-N", chain)
-
-
-def clear_iptables(blockade_id):
-    """Remove all iptables rules and chains related to this blockade
-    """
-    # first remove refererences to our custom chains
-    iptables_delete_blockade_rules(blockade_id)
-
-    # then remove the chains themselves
-    iptables_delete_blockade_chains(blockade_id)
-
-
 def _get_chain_groups(partitions):
     chains = []
 
@@ -304,61 +373,3 @@ def _get_chain_groups(partitions):
 
     # prune empty partitions
     return [x for x in chains if len(x) > 0]
-
-
-def partition_containers(blockade_id, partitions):
-    if not partitions or len(partitions) == 1:
-        return
-
-    # partitions without IP addresses can't be part of any
-    # iptables rule anyway
-    ip_partitions = [[c for c in parts if c.ip_address] for parts in partitions]
-
-    all_nodes = frozenset(itertools.chain(*ip_partitions))
-
-    for idx, chain_group in enumerate(_get_chain_groups(ip_partitions)):
-        # create a new chain
-        chain_name = partition_chain_name(blockade_id, idx+1)
-        iptables_create_chain(chain_name)
-
-        # direct all traffic of the chain group members to this chain
-        for container in chain_group:
-            iptables_insert_rule("FORWARD", src=container.ip_address, target=chain_name)
-
-        def in_group(container):
-            return any(container.name == x.name for x in chain_group)
-
-        # block all transfer of partitions the containers of this chain group  are NOT part of
-        chain_partition_members = set(itertools.chain(*[parts for parts in ip_partitions
-                                                        if any(in_group(c) for c in parts)]))
-        to_block = all_nodes - chain_partition_members
-
-        for container in to_block:
-            iptables_insert_rule(chain_name, dest=container.ip_address, target="DROP")
-
-
-def traffic_control_restore(device):
-    cmd = ["tc", "qdisc", "del", "dev", device, "root"]
-    docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
-
-
-def traffic_control_netem(device, params):
-    cmd = ["tc", "qdisc", "replace", "dev", device,
-           "root", "netem"] + params
-    docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
-
-
-def network_state(device):
-    cmd = ["tc", "qdisc", "show", "dev", device]
-    try:
-        output = docker_run(' '.join(cmd), image=IPTABLES_DOCKER_IMAGE)
-        # sloppy but good enough for now
-        if " delay " in output:
-            return NetworkState.SLOW
-        if " loss " in output:
-            return NetworkState.FLAKY
-        if " duplicate " in output:
-            return NetworkState.DUPLICATE
-        return NetworkState.NORMAL
-    except Exception:
-        return NetworkState.UNKNOWN

--- a/blockade/tests/helpers.py
+++ b/blockade/tests/helpers.py
@@ -1,0 +1,60 @@
+#
+#  Copyright (C) 2017 Quest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import uuid
+import logging
+
+import docker
+
+import blockade.host
+
+
+_logger = logging.getLogger(__name__)
+
+
+class HostExecHelper(object):
+    def __init__(self):
+        self.prefix = "blockade-test-" + uuid.uuid4().hex[:8]
+        self.docker = docker.Client(
+            **docker.utils.kwargs_from_env(assert_hostname=False))
+
+    def setup_prefix_env(self):
+        os.environ[blockade.host.CONTAINER_PREFIX_ENV] = self.prefix
+
+    def tearDown(self):
+        containers = self.find_created_containers()
+        if containers:
+            for c in containers:
+                try:
+                    self.docker.kill(c)
+                except docker.errors.APIError:
+                    pass  # already dead
+
+                try:
+                    self.docker.remove_container(c, force=True)
+                except docker.errors.APIError as e:
+                    if not "already in progress" in str(e):
+                        _logger.exception("Failed to remove container %s", c)
+
+            raise Exception("Test failed to tear down %d created container(s). "
+                      "They have been removed." % len(containers))
+
+    def find_created_containers(self):
+        containers = self.docker.containers(all=True)
+
+        return [c['Id'] for c in containers
+                if any(name.startswith("/"+self.prefix) for name in c['Names'])]

--- a/blockade/tests/test_host.py
+++ b/blockade/tests/test_host.py
@@ -1,0 +1,194 @@
+#
+#  Copyright (C) 2017 Quest, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import time
+import unittest
+import threading
+import logging
+
+import docker
+
+from blockade.host import HostExec
+from blockade.errors import HostExecError
+from blockade.tests.test_integration import INT_SKIP
+from blockade.tests.helpers import HostExecHelper
+
+
+_logger = logging.getLogger(__name__)
+
+_GET_CONTAINER_ID_CMD = ["sh", "-c",
+    "cat /proc/self/cgroup | grep docker | grep -o -E '[0-9a-f]{64}' "
+    "| head -n 1"]
+
+
+class HostExecTests(unittest.TestCase):
+
+    def setUp(self):
+        self.helper = HostExecHelper()
+
+        self.docker = docker.Client(
+            **docker.utils.kwargs_from_env(assert_hostname=False))
+
+    def tearDown(self):
+        self.helper.tearDown()
+
+    def assert_no_containers(self):
+        self.assertEqual(self.helper.find_created_containers(), [])
+
+    def get_host_exec(self, **kwargs):
+        return HostExec(container_prefix=self.helper.prefix, **kwargs)
+
+    def test_reuse_container(self):
+        """test that containers are reused"""
+        # no containers should be running
+        self.assert_no_containers()
+
+        # run one process, which should start a container and leave it running
+
+        host_exec = self.get_host_exec()
+        container_hostname_1 = host_exec.run(_GET_CONTAINER_ID_CMD).strip()
+        self.assertTrue(container_hostname_1)
+
+        containers_1 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_1), 1)
+        self.assertTrue(containers_1[0].startswith(container_hostname_1))
+
+        # run another process, which should reuse the existing container
+        container_hostname_2 = host_exec.run(_GET_CONTAINER_ID_CMD).strip()
+        containers_2 = self.helper.find_created_containers()
+        self.assertEqual(containers_1, containers_2)
+        self.assertEqual(container_hostname_1, container_hostname_2)
+
+        host_exec.close()
+        self.assert_no_containers()
+
+        container_hostname_3 = host_exec.run(_GET_CONTAINER_ID_CMD).strip()
+        self.assertNotEqual(container_hostname_3, container_hostname_1)
+        containers_3 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_3), 1)
+        self.assertTrue(containers_3[0].startswith(container_hostname_3))
+
+        host_exec.close()
+
+    def test_killed_container(self):
+        """test that dead containers are gracefully replaced"""
+        host_exec = self.get_host_exec()
+        host_exec.run(["hostname"])
+
+        containers_1 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_1), 1)
+        self.docker.kill(containers_1[0])
+
+        host_exec.run(["hostname"])
+        containers_2 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_2), 1)
+        self.assertNotEqual(containers_1, containers_2)
+
+        host_exec.close()
+
+    def test_removed_container(self):
+        """test that missing containers are gracefully replaced"""
+        host_exec = self.get_host_exec()
+        host_exec.run(["hostname"])
+
+        containers_1 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_1), 1)
+        self.docker.kill(containers_1[0])
+        self.docker.remove_container(containers_1[0])
+
+        host_exec.run(["hostname"])
+        containers_2 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_2), 1)
+        self.assertNotEqual(containers_1, containers_2)
+
+        host_exec.close()
+
+    def test_close_removed_container(self):
+        """test that close() handles missing containers gracefully"""
+        host_exec = self.get_host_exec()
+        host_exec.run(["hostname"])
+
+        containers_1 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_1), 1)
+        self.docker.kill(containers_1[0])
+        self.docker.remove_container(containers_1[0])
+        host_exec.close()
+
+    def test_expired_container(self):
+        """ test that containers are replaced upon expiration"""
+        host_exec = self.get_host_exec()
+        host_exec.run(["hostname"])
+
+        containers_1 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_1), 1)
+
+        # ensure that expire time was set approximately correctly
+        time_left = host_exec._container_expire_time - time.time()
+        self.assertTrue(0 < time_left < host_exec._container_expire)
+
+        # forcibly set expire time to ensure that next call triggers
+        host_exec._container_expire_time = time.time()
+
+        host_exec.run(["hostname"])
+        containers_2 = self.helper.find_created_containers()
+        self.assertEqual(len(containers_2), 1)
+        self.assertNotEqual(containers_1, containers_2)
+
+        host_exec.close()
+
+    def test_command_error(self):
+        """test that commands with nonzero exit codes result in exceptions
+        """
+        host_exec = self.get_host_exec()
+        with self.assertRaises(HostExecError) as cm:
+            host_exec.run(["false"])
+        _logger.debug(cm.exception)
+        host_exec.close()
+
+    @unittest.skipIf(*INT_SKIP)
+    def test_parallel_run(self):
+        """test that many commands can be run in parallel"""
+
+        host_exec = self.get_host_exec()
+        event = threading.Event()
+
+        error_lock = threading.Lock()
+        errors = []
+
+        def _thread():
+            try:
+                assert event.wait(60)
+                for _ in range(10):
+                    host_exec.run(["hostname"])
+
+            except Exception as e:
+                with error_lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=_thread) for _ in range(10)]
+
+        for t in threads:
+            t.daemon = True
+            t.start()
+
+        event.set()
+
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+
+        host_exec.close()

--- a/blockade/tests/test_integration.py
+++ b/blockade/tests/test_integration.py
@@ -228,12 +228,12 @@ class IntegrationTests(unittest.TestCase):
                 f.write(dedent('''\
                     containers:
                       zzz:
-                        image: ubuntu:trusty
-                        command: sleep infinity
+                        image: krallin/ubuntu-tini:trusty
+                        command: ["sleep", "infinity"]
                         expose: [10000]
                       aaa:
-                        image: ubuntu:trusty
-                        command: sleep infinity
+                        image: krallin/ubuntu-tini:trusty
+                        command: ["sleep", "infinity"]
                         links: ["zzz"]
                     '''))
 
@@ -265,12 +265,12 @@ class IntegrationTests(unittest.TestCase):
                     containers:
                       zzz:
                         container_name: zzz
-                        image: ubuntu:trusty
-                        command: sh -c "sleep 3 && ping -i1 -c3 aaa && sleep infinity"
+                        image: krallin/ubuntu-tini:trusty
+                        command: ["sh", "-c", "sleep 3 && ping -i1 -c3 aaa && sleep infinity"]
                       aaa:
                         container_name: aaa
-                        image: ubuntu:trusty
-                        command: sh -c "sleep 3 && ping -i1 -c3 zzz && sleep infinity"
+                        image: krallin/ubuntu-tini:trusty
+                        command: ["sh", "-c", "sleep 3 && ping -i1 -c3 zzz && sleep infinity"]
                     network:
                       driver: udn
                     '''))

--- a/blockade/tests/test_integration_rest.py
+++ b/blockade/tests/test_integration_rest.py
@@ -13,26 +13,96 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import os
 import time
+import signal
+import random
+import multiprocessing
+
+import requests
 from flask.ext.testing import LiveServerTestCase
 
-from blockade.api.rest import app
+from blockade.api.rest import app, stack_trace_handler
+from blockade.api.manager import BlockadeManager
+from blockade.host import HostExec
 from blockade.tests import unittest
 from blockade.tests.test_integration import INT_SKIP
+from blockade.tests.helpers import HostExecHelper
+from blockade.tests.util import wait
 
-import random
-import requests
+
+def wait_for_children():
+    """Wait for child processes to exit
+
+    The testing system launches and terminates child processes, but
+    doesn't wait for them to actually die. So in a few places we need
+    this extra call"""
+    wait(lambda: len(multiprocessing.active_children()) == 0)
 
 
+@unittest.skipIf(*INT_SKIP)
 class RestIntegrationTests(LiveServerTestCase):
 
     headers = {'Content-Type': 'application/json'}
+    host_exec_helper = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.host_exec_helper = HostExecHelper()
+        # this sets up an environment variable that controls the prefix
+        # used for all host exec helper containers. This env will be
+        # respected by the Flask app child process, and allows us to
+        # assert that containers are correctly torn down by the testing
+        # rig.
+        cls.host_exec_helper.setup_prefix_env()
+
+    @classmethod
+    def tearDownClass(cls):
+
+        # LiveServerTestCase sends SIGTERM to child processes, but doesn't
+        # wait for exit. So we wait up to 9 seconds for all children to be
+        # gone.
+        wait_for_children()
+
+        if cls.host_exec_helper:
+            cls.host_exec_helper.tearDown()
 
     def create_app(self):
+        # HACK: wait for any previous processes to exit. We do it here because
+        # this is the only opportunity LiveServerTestCase provides:
+        # setUp/tearDown is too late/early.
+        wait_for_children()
+
         app.config['TESTING'] = True
+        app.config['DEBUG'] = True
+
+        # LiveServerTestCase runs the server in a multiprocessing.Process,
+        # and doesn't provide an obvious place for setup/teardown logic
+        # *in* the child process. So we monkeypatch app.run to set up a
+        # SIGTERM handler that runs our HostExec cleanup.
+
+        real_run = app.run
+
+        def _wrapped_run(*args, **kwargs):
+            host_exec = HostExec()
+            BlockadeManager.set_host_exec(host_exec)
+
+            def _cleanup_host_exec(*args):
+                host_exec.close()
+                os._exit(0)
+
+            signal.signal(signal.SIGTERM, _cleanup_host_exec)
+            signal.signal(signal.SIGUSR2, stack_trace_handler)
+
+            real_run(*args, **kwargs)
+
+        app.run = _wrapped_run
+
         return app
 
     def setUp(self):
+
         data = '''
             {
                 "containers": {

--- a/blockade/tests/test_integration_rest.py
+++ b/blockade/tests/test_integration_rest.py
@@ -107,14 +107,14 @@ class RestIntegrationTests(LiveServerTestCase):
             {
                 "containers": {
                     "c1": {
-                        "image": "ubuntu:trusty",
+                        "image": "krallin/ubuntu-tini:trusty",
                         "hostname": "c1",
-                        "command": "/bin/sleep 300"
+                        "command": ["/bin/sleep", "300"]
                     },
                     "c2": {
-                        "image": "ubuntu:trusty",
+                        "image": "krallin/ubuntu-tini:trusty",
                         "hostname": "c2",
-                        "command": "/bin/sleep 300"
+                        "command": ["/bin/sleep", "300"]
                     }
                 }
             }

--- a/blockade/tests/test_net.py
+++ b/blockade/tests/test_net.py
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
+import shlex
+
+import mock
+
 from blockade.net import BlockadeNetwork
 from blockade.net import NetworkState
 from blockade.net import parse_partition_index
 from blockade.net import partition_chain_name
 from blockade.tests import unittest
-
-import blockade.net
-
-import mock
-
+from blockade.errors import HostExecError
 
 NORMAL_QDISC_SHOW = "qdisc pfifo_fast 0: root refcnt 2 bands 3 priomap\n"
 SLOW_QDISC_SHOW = "qdisc netem 8011: root refcnt 2 limit 1000 delay 50.0ms\n"
@@ -95,109 +95,110 @@ target     prot opt source               destination
 
 
 class NetTests(unittest.TestCase):
-    def test_iptables_get_blockade_chains(self):
+    def test_get_ip_partitions(self):
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
         blockade_id = "e5dcf85cd2"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = _IPTABLES_LIST_FORWARD_1
-            result = blockade.net.iptables_get_source_chains(blockade_id)
+        mock_run.return_value = _IPTABLES_LIST_FORWARD_1
 
-            self.assertEqual(1, mock_docker_run.call_count)
-            self.assertEqual({"172.17.0.162": 1, "172.17.0.164": 1}, result)
+        net = BlockadeNetwork(None, mock_host_exec)
+        result = net.get_ip_partitions(blockade_id)
+
+        self.assertEqual(1, mock_run.call_count)
+        self.assertEqual({"172.17.0.162": 1, "172.17.0.164": 1}, result)
 
     def test_iptables_delete_blockade_rules_1(self):
         blockade_id = "e5dcf85cd2"
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = _IPTABLES_LIST_FORWARD_1
-            blockade.net.iptables_delete_blockade_rules(blockade_id)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.return_value = _IPTABLES_LIST_FORWARD_1
 
-            self.assertEqual(3, mock_docker_run.call_count)
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.delete_blockade_rules(blockade_id)
 
-            # rules should be removed in reverse order
-            expected_calls = [
-                mock.call("iptables -n -L FORWARD", image=expected_image),
-                mock.call("iptables -D FORWARD 4", image=expected_image),
-                mock.call("iptables -D FORWARD 3", image=expected_image)
-            ]
-            self.assertEqual(expected_calls, mock_docker_run.call_args_list)
+        self.assertEqual(3, mock_run.call_count)
+
+        # rules should be removed in reverse order
+        expected_calls = [
+            mock.call(["iptables", "-n", "-L", "FORWARD"]),
+            mock.call(["iptables", "-D", "FORWARD", "4"]),
+            mock.call(["iptables", "-D", "FORWARD", "3"])
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
 
     def test_iptables_delete_blockade_rules_2(self):
         blockade_id = "e5dcf85cd2"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = _IPTABLES_LIST_FORWARD_2
-            blockade.net.iptables_delete_blockade_rules(blockade_id)
-
-            self.assertEqual(1, mock_docker_run.call_count)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.return_value = _IPTABLES_LIST_FORWARD_2
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.delete_blockade_rules(blockade_id)
+        self.assertEqual(1, mock_run.call_count)
 
     def test_iptables_delete_blockade_chains_1(self):
         blockade_id = "e5dcf85cd2"
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = _IPTABLES_LIST_1
-            blockade.net.iptables_delete_blockade_chains(blockade_id)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.return_value = _IPTABLES_LIST_1
+        net = BlockadeNetwork(None, mock_host_exec)
 
-            self.assertEqual(5, mock_docker_run.call_count)
+        net.iptables.delete_blockade_chains(blockade_id)
 
-            expected_calls = [
-                mock.call("iptables -n -L", image=expected_image),
-                mock.call("iptables -F blockade-e5dcf85cd2-p1", image=expected_image),
-                mock.call("iptables -X blockade-e5dcf85cd2-p1", image=expected_image),
-                mock.call("iptables -F blockade-e5dcf85cd2-p2", image=expected_image),
-                mock.call("iptables -X blockade-e5dcf85cd2-p2", image=expected_image)]
-            self.assertEqual(expected_calls, mock_docker_run.call_args_list)
+        self.assertEqual(5, mock_run.call_count)
+
+        expected_calls = [
+            mock.call(shlex.split("iptables -n -L")),
+            mock.call(shlex.split("iptables -F blockade-e5dcf85cd2-p1")),
+            mock.call(shlex.split("iptables -X blockade-e5dcf85cd2-p1")),
+            mock.call(shlex.split("iptables -F blockade-e5dcf85cd2-p2")),
+            mock.call(shlex.split("iptables -X blockade-e5dcf85cd2-p2"))]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
 
     def test_iptables_delete_blockade_chains_2(self):
         blockade_id = "e5dcf85cd2"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = _IPTABLES_LIST_2
-            blockade.net.iptables_delete_blockade_chains(blockade_id)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.return_value = _IPTABLES_LIST_2
+        net = BlockadeNetwork(None, mock_host_exec)
 
-            self.assertEqual(1, mock_docker_run.call_count)
+        net.iptables.delete_blockade_chains(blockade_id)
+
+        self.assertEqual(1, mock_run.call_count)
 
     def test_iptables_insert_rule_1(self):
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            blockade.net.iptables_insert_rule("FORWARD",
-                                              src="192.168.0.1",
-                                              target="DROP")
-            cmd = ["iptables", "-I", "FORWARD", "-s", "192.168.0.1",
-                   "-j", "DROP"]
-            mock_docker_run.assert_called_once_with(
-                ' '.join(cmd), image=expected_image
-            )
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.insert_rule("FORWARD", src="192.168.0.1", target="DROP")
+        cmd = ["iptables", "-I", "FORWARD", "-s", "192.168.0.1", "-j", "DROP"]
+        mock_run.assert_called_once_with(cmd)
 
     def test_iptables_insert_rule_2(self):
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            blockade.net.iptables_insert_rule("FORWARD", src="192.168.0.1",
-                                              dest="192.168.0.2",
-                                              target="DROP")
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.insert_rule("FORWARD", src="192.168.0.1",
+            dest="192.168.0.2", target="DROP")
 
-            cmd = ["iptables", "-I", "FORWARD", "-s", "192.168.0.1",
-                   "-d", "192.168.0.2", "-j", "DROP"]
-            mock_docker_run.assert_called_once_with(
-                ' '.join(cmd), image=expected_image
-            )
+        cmd = ["iptables", "-I", "FORWARD", "-s", "192.168.0.1", "-d",
+            "192.168.0.2", "-j", "DROP"]
+        mock_run.assert_called_once_with(cmd)
 
     def test_iptables_insert_rule_3(self):
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            blockade.net.iptables_insert_rule("FORWARD", dest="192.168.0.2",
-                                              target="DROP")
-            cmd = ["iptables", "-I", "FORWARD", "-d", "192.168.0.2",
-                   "-j", "DROP"]
-            mock_docker_run.assert_called_once_with(
-                ' '.join(cmd), image=expected_image
-            )
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.insert_rule("FORWARD", dest="192.168.0.2", target="DROP")
+        cmd = ["iptables", "-I", "FORWARD", "-d", "192.168.0.2", "-j", "DROP"]
+        mock_run.assert_called_once_with(cmd)
 
     def test_iptables_create_chain(self):
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            blockade.net.iptables_create_chain("hats")
-            cmd = ["iptables", "-N", "hats"]
-            mock_docker_run.assert_called_once_with(
-                ' '.join(cmd), image=expected_image
-            )
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        net = BlockadeNetwork(None, mock_host_exec)
+        net.iptables.create_chain("hats")
+        cmd = ["iptables", "-N", "hats"]
+        mock_run.assert_called_once_with(cmd)
 
     def test_partition_chain_parse(self):
         blockade_id = "abc123"
@@ -238,105 +239,99 @@ class NetTests(unittest.TestCase):
             parse_partition_index(blockade_id, "abc123")
 
     def test_partition_1(self):
+
+        def iptables(args):
+            if args == ["iptables", "-n", "-L"]:
+                return _IPTABLES_LIST_2
+            if args == ["iptables", "-n", "-L", "FORWARD"]:
+                return _IPTABLES_LIST_FORWARD_2
+            return ""
+
         blockade_id = "e5dcf85cd2"
-        expected_image=blockade.net.IPTABLES_DOCKER_IMAGE
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = ""
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.side_effect = iptables
+        net = BlockadeNetwork(None, mock_host_exec)
 
-            blockade.net.partition_containers(blockade_id, [
-                    # partition 1
-                    [mock.Mock(name="c1", ip_address="10.0.1.1"),
-                     mock.Mock(name="c2", ip_address="10.0.1.2")],
-                    # partition 2
-                    [mock.Mock(name="c3", ip_address="10.0.1.3")]
-                ]
-            )
+        net.partition_containers(blockade_id, [
+            # partition 1
+            [mock.Mock(name="c1", ip_address="10.0.1.1"),
+             mock.Mock(name="c2", ip_address="10.0.1.2")],
+            # partition 2
+            [mock.Mock(name="c3", ip_address="10.0.1.3")]
+        ])
 
-            mock_docker_run.assert_has_calls([
-                # create a chain for each partition
-                mock.call(
-                    "iptables -N blockade-e5dcf85cd2-p1",
-                    image=expected_image
-                ),
-                # forward traffic from each node in p1 to its new chain
-                mock.call(
-                    "iptables -I FORWARD -s 10.0.1.1 -j blockade-e5dcf85cd2-p1",
-                    image=expected_image
-                ),
-                mock.call(
-                    "iptables -I FORWARD -s 10.0.1.2 -j blockade-e5dcf85cd2-p1",
-                    image=expected_image
-                ),
-                # and drop any traffic from this partition directed
-                # at any container not in this partition
-                mock.call(
-                    "iptables -I blockade-e5dcf85cd2-p1 -d 10.0.1.3 -j DROP",
-                    image=expected_image
-                ),
-            ], any_order=True)
+        mock_run.assert_has_calls([
+            # create a chain for each partition
+            mock.call(shlex.split("iptables -N blockade-e5dcf85cd2-p1")),
+            # forward traffic from each node in p1 to its new chain
+            mock.call(shlex.split(
+                "iptables -I FORWARD -s 10.0.1.1 -j blockade-e5dcf85cd2-p1")),
+            mock.call(shlex.split(
+                "iptables -I FORWARD -s 10.0.1.2 -j blockade-e5dcf85cd2-p1")),
+            # and drop any traffic from this partition directed
+            # at any container not in this partition
+            mock.call(shlex.split(
+                "iptables -I blockade-e5dcf85cd2-p1 -d 10.0.1.3 -j DROP")),
+        ], any_order=True)
 
-            mock_docker_run.assert_has_calls([
-                # now repeat the process for the second partition
-                mock.call(
-                    "iptables -N blockade-e5dcf85cd2-p2",
-                    image=expected_image
-                ),
-                mock.call(
-                    "iptables -I FORWARD -s 10.0.1.3 -j blockade-e5dcf85cd2-p2",
-                    image=expected_image
-                ),
-                mock.call(
-                    "iptables -I blockade-e5dcf85cd2-p2 -d 10.0.1.1 -j DROP",
-                    image=expected_image
-                ),
-                mock.call(
-                    "iptables -I blockade-e5dcf85cd2-p2 -d 10.0.1.2 -j DROP",
-                    image=expected_image
-                ),
-            ], any_order=True)
+        mock_run.assert_has_calls([
+            # now repeat the process for the second partition
+            mock.call(shlex.split("iptables -N blockade-e5dcf85cd2-p2")),
+            mock.call(shlex.split(
+                "iptables -I FORWARD -s 10.0.1.3 -j blockade-e5dcf85cd2-p2")),
+            mock.call(shlex.split(
+                "iptables -I blockade-e5dcf85cd2-p2 -d 10.0.1.1 -j DROP")),
+            mock.call(shlex.split(
+                "iptables -I blockade-e5dcf85cd2-p2 -d 10.0.1.2 -j DROP")),
+        ], any_order=True)
 
     def test_network_already_normal(self):
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = "", QDISC_DEL_NOENT
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        net = BlockadeNetwork(None, mock_host_exec)
+        mock_run.side_effect = HostExecError("", exit_code=2,
+            output=QDISC_DEL_NOENT)
 
-            net = BlockadeNetwork(mock.Mock())
-
-            # ensure we don't raise an error
-            net.fast('somedevice')
-            self.assertIn('somedevice', mock_docker_run.call_args[0][0])
+        # ensure we don't raise an error
+        net.fast('somedevice')
+        self.assertIn('somedevice', mock_run.call_args[0][0])
 
     def test_slow(self):
         slow_config = "75ms 100ms distribution normal"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_config = mock.Mock()
-            mock_config.network = {"slow": slow_config}
-            net = BlockadeNetwork(mock_config)
-            net.slow("mydevice")
-            cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
-                   "root", "netem", "delay"] + slow_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_config = mock.Mock()
+        mock_config.network = {"slow": slow_config}
+        net = BlockadeNetwork(mock_config, mock_host_exec)
+        net.slow("mydevice")
+        cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
+               "root", "netem", "delay"] + slow_config.split()
+        mock_run.assert_called_once_with(cmd)
 
     def test_flaky(self):
         flaky_config = "30%"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_config = mock.Mock()
-            mock_config.network = {"flaky": flaky_config}
-            net = BlockadeNetwork(mock_config)
-            net.flaky("mydevice")
-            cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
-                   "root", "netem", "loss"] + flaky_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_config = mock.Mock()
+        mock_config.network = {"flaky": flaky_config}
+        net = BlockadeNetwork(mock_config, mock_host_exec)
+        net.flaky("mydevice")
+        cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
+               "root", "netem", "loss"] + flaky_config.split()
+        mock_run.assert_called_once_with(cmd)
 
     def test_duplicate(self):
         duplicate_config = "5%"
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_config = mock.Mock()
-            mock_config.network = {"duplicate": duplicate_config}
-            net = BlockadeNetwork(mock_config)
-            net.duplicate("mydevice")
-            cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
-                   "root", "netem", "duplicate"] + duplicate_config.split()
-            mock_docker_run.assert_called_once_with(' '.join(cmd), image=blockade.net.IPTABLES_DOCKER_IMAGE)
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_config = mock.Mock()
+        mock_config.network = {"duplicate": duplicate_config}
+        net = BlockadeNetwork(mock_config, mock_host_exec)
+        net.duplicate("mydevice")
+        cmd = ["tc", "qdisc", "replace", "dev", "mydevice",
+               "root", "netem", "duplicate"] + duplicate_config.split()
+        mock_run.assert_called_once_with(cmd)
 
     def test_network_state_slow(self):
         self._network_state(NetworkState.SLOW, SLOW_QDISC_SHOW)
@@ -348,9 +343,10 @@ class NetTests(unittest.TestCase):
         self._network_state(NetworkState.FLAKY, FLAKY_QDISC_SHOW)
 
     def _network_state(self, state, output):
-        with mock.patch('blockade.net.docker_run') as mock_docker_run:
-            mock_docker_run.return_value = output
+        mock_host_exec = mock.Mock()
+        mock_run = mock_host_exec.run
+        mock_run.return_value = output
 
-            net = BlockadeNetwork(mock.Mock())
-            self.assertEqual(net.network_state('somedevice'), state)
-            self.assertIn('somedevice', mock_docker_run.call_args[0][0])
+        net = BlockadeNetwork(mock.Mock(), mock_host_exec)
+        self.assertEqual(net.network_state('somedevice'), state)
+        self.assertIn('somedevice', mock_run.call_args[0][0])

--- a/examples/ping/blockade.yaml
+++ b/examples/ping/blockade.yaml
@@ -1,21 +1,21 @@
 containers:
   c1:
-    image: ubuntu:trusty
+    image: krallin/ubuntu-tini:trusty
     hostname: c1
-    command: /bin/sleep 30000
+    command: ["/bin/sleep", "30000"]
     # this port is unused, but we need at least one open for docker links
     expose: [10000]
 
   c2:
-    image: ubuntu:trusty
+    image: krallin/ubuntu-tini:trusty
     hostname: c2
-    command: sh -c "ping -i1 $C1_PORT_10000_TCP_ADDR"
+    command: ["sh", "-c", "ping -i1 $C1_PORT_10000_TCP_ADDR"]
     links: ["c1"]
 
   c3:
-    image: ubuntu:trusty
+    image: krallin/ubuntu-tini:trusty
     hostname: c3
-    command: sh -c "ping -i1 $C1_PORT_10000_TCP_ADDR"
+    command: ["sh", "-c", "ping -i1 $C1_PORT_10000_TCP_ADDR"]
     links: ["c1"]
 
 network:

--- a/examples/sleep/blockade.yaml
+++ b/examples/sleep/blockade.yaml
@@ -1,16 +1,17 @@
 containers:
   c1:
-    image: ubuntu:trusty
+    # run commands under tini, so signals are correctly proxied
+    image: krallin/ubuntu-tini:trusty
     hostname: c1
-    command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
+    command: ["sh", "-c", "echo I am $HOSTNAME; /bin/sleep 300"]
     volumes: {"/tmp": "/mnt"}
 
   c2:
-    image: ubuntu:trusty
+    image: krallin/ubuntu-tini:trusty
     hostname: c2
-    command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
+    command: ["sh", "-c", "echo I am $HOSTNAME; /bin/sleep 300"]
 
   c3:
-    image: ubuntu:trusty
+    image: krallin/ubuntu-tini:trusty
     hostname: c3
-    command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
+    command: ["sh", "-c", "echo I am $HOSTNAME; /bin/sleep 300"]


### PR DESCRIPTION
This is an optimization that improves the performance of all the host commands (iptables, tc, etc) run by blockade. Instead of running each command in its own container, a reusable (but ephemeral) container is kept running and multiple commands are run in it via exec. This container is configured to die on its own if orphaned, and will also be periodically replaced by blockade. It is harmless for the container to be killed (so long as no commands are executing at that moment), as blockade will replace it on next use. Blockade kills the container upon exit.

This change required a substantial refactor of the net module: I pulled many of the top-level functions into helper classes. This was long overdue, and makes it easier to inject dependencies, and write tests.
